### PR TITLE
Add `request/are-updating` subscription

### DIFF
--- a/src/re_frame_request/events.cljs
+++ b/src/re_frame_request/events.cljs
@@ -8,7 +8,7 @@
 (defn ajax-xhrio-handler
   {:attribution "https://github.com/Day8/re-frame-http-fx"
    :doc "ajax-request only provides a single handler for success and errors"}
-  [on-success on-failure xhrio [success? response]]
+  [on-success on-failure ^js xhrio [success? response]]
   (if success?
     (on-success response)
     (let [details (merge

--- a/src/re_frame_request/subscriptions.cljs
+++ b/src/re_frame_request/subscriptions.cljs
@@ -17,6 +17,16 @@
 
   (reg-sub
    :request/is-dispatching
-   (fn [_ [_ request-name]] (subscribe [:request/core]))
+   (fn [_ [_ _]] (subscribe [:request/core]))
    (fn [request [_ request-name]]
-     (= :loading (get-in request [request-name :status])))))
+     (= :loading (get-in request [request-name :status]))))
+  
+  (reg-sub
+   :request/any-dispatching
+   (fn [_ [_ _]] (subscribe [:request/core]))
+   (fn [request [_ & request-names]]
+     (->> request-names
+          (map #(get-in request [% :status]))
+          (into #{})
+          :loading
+          some?))))


### PR DESCRIPTION
Useful for when a view needs to know the request dispatch status for multiple requests.